### PR TITLE
examples: fix and improve init script

### DIFF
--- a/examples/droppy.init.d
+++ b/examples/droppy.init.d
@@ -10,27 +10,29 @@
 # Description:       droppy - github.com/droppyjs/droppy
 ### END INIT INFO
 
-DROPPY_CONFIG_DIR="/srv/droppy/config"
-DROPPY_FILES_DIR="/srv/droppy/files"
-
-PROCESS="droppy"
+CONFIG="/srv/droppy/config"
+FILES="/srv/droppy/files"
+BINARY="/usr/local/bin/droppy"
 RUNAS="droppy:droppy"
-CMD="/usr/bin/env droppy -- start -c '$DROPPY_CONFIG_DIR' -f '$DROPPY_FILES_DIR'"
+PIDFILE="/run/droppy.pid"
 
 do_start() {
-    start-stop-daemon --start --background -c $RUNAS --name $PROCESS --exec $CMD 
+    start-stop-daemon --start --background \
+      --pidfile "$PIDFILE" --make-pidfile -c "$RUNAS" \
+      --exec "$BINARY" -- start -c "$CONFIG" -f "$FILES"
 }
 
 do_stop() {
-    start-stop-daemon --stop --name $PROCESS
+    start-stop-daemon --stop --oknodo \
+       --pidfile "$PIDFILE" --remove-pidfile -c "$RUNAS"
 }
 
 do_status() {
-    if pgrep -x "$PROCESS" >/dev/null
+    if start-stop-daemon --status --pidfile "$PIDFILE" -c "$RUNAS"
     then
-        echo "$PROCESS is running"
+        echo "$BINARY is running"
     else
-        echo "$PROCESS stopped"
+        echo "$BINARY stopped"
     fi
 }
 


### PR DESCRIPTION
### What are the changes and their implications?

Fix the example init script that doesn't work on debian 12, with droppy installed with `npm install -g @droppyjs/cli`.

What I changed to fix and improve it so it works better:
- args `-c` and `-f` are not read because of `--` and it falls back to the `~/.droppy` default
- process isn't `droppy` but `@droppyjs/cli` so it doesn't match
- use a pid file instead, more reliable

### Checklist

- [ n/a ] Changes covered by tests (tests added if needed)
- [ n/a ] PR submitted to [droppyjs.com](https://github.com/droppyjs/droppyjs.com) for any user facing changes

Thanks for the fork and maintaining it <3